### PR TITLE
Change driverController to static

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -21,11 +21,11 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
  */
 public class RobotContainer {
 	// Replace with CommandPS4Controller or CommandJoystick if needed
-	private final CommandXboxController driverController = new CommandXboxController(
+	public static final CommandXboxController driverController = new CommandXboxController(
 			OperatorConstants.DRIVER_CONTROLLER_PORT);
 
 	// The robot's subsystems and commands are defined here...
-	private final Drivetrain drivetrain = new Drivetrain(driverController);
+	private final Drivetrain drivetrain = new Drivetrain();
 
 	/**
 	 * The container for the robot. Contains subsystems, OI devices, and commands.

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -10,6 +10,7 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj.motorcontrol.MotorController;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import frc.robot.RobotContainer;
 import frc.robot.Constants.ControlConstants;
 import frc.robot.Constants.OperatorConstants;
 
@@ -19,10 +20,8 @@ public class Drivetrain extends SubsystemBase {
 	private MotorController frontRight;
 	private MotorController backLeft;
 	private MotorController backRight;
-	private CommandXboxController controller;
 
-	public Drivetrain(CommandXboxController controller) {
-		this.controller = controller;
+	public Drivetrain() {
 
 		frontLeft = new CANSparkMax(0, MotorType.kBrushless);
 		frontRight = new CANSparkMax(1, MotorType.kBrushless);
@@ -35,10 +34,10 @@ public class Drivetrain extends SubsystemBase {
 
 	@Override
 	public void periodic() {
-		double joyX = controller.getRawAxis(OperatorConstants.XBOX_LEFT_X_AXIS);
-		double joyY = -controller.getRawAxis(OperatorConstants.XBOX_LEFT_Y_AXIS);
+		double joyX = RobotContainer.driverController.getRawAxis(OperatorConstants.XBOX_LEFT_X_AXIS);
+		double joyY = -RobotContainer.driverController.getRawAxis(OperatorConstants.XBOX_LEFT_Y_AXIS);
 		double rotation = ControlConstants.ROTATION_MULT
-				* (controller.getRightTriggerAxis() - controller.getLeftTriggerAxis());
+				* (RobotContainer.driverController.getRightTriggerAxis() - RobotContainer.driverController.getLeftTriggerAxis());
 
 		mecanumDrive(joyX, joyY, rotation);
 	}


### PR DESCRIPTION
The previous implementation used the `CommandXboxController` as a private instance passed to each command/subsystem

This has been updated to a public static instance for alignment with standards and for the sake of simplicity
